### PR TITLE
Enables project ordering within categories

### DIFF
--- a/scripts/add-ordering-field-migration.sql
+++ b/scripts/add-ordering-field-migration.sql
@@ -1,0 +1,22 @@
+-- Add ordering field to folders table
+-- This allows subfolder ordering within each parent category
+
+ALTER TABLE folders
+ADD COLUMN ordering INTEGER DEFAULT 0;
+
+-- Update existing subfolders to have sequential ordering within their parent
+-- This ensures consistent ordering for existing data
+WITH ordered_folders AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (PARTITION BY parent_id ORDER BY created_at) as row_num
+  FROM folders
+  WHERE is_parent = false
+)
+UPDATE folders
+SET ordering = ordered_folders.row_num
+FROM ordered_folders
+WHERE folders.id = ordered_folders.id;
+
+-- Create index for efficient ordering queries
+CREATE INDEX IF NOT EXISTS idx_folders_parent_ordering ON folders(parent_id, ordering) WHERE is_parent = false;

--- a/src/components/project-listing.tsx
+++ b/src/components/project-listing.tsx
@@ -1,0 +1,149 @@
+"use client"
+
+import type React from "react"
+import { useState, useCallback } from "react"
+import { Card } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { GripVertical, ArrowLeft, Image as ImageIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { ProjectWithFirstImage } from "@/modules/database/types"
+
+type ProjectListingProps = {
+  categoryName: string
+  projects: ProjectWithFirstImage[]
+  onBack: () => void
+  onProjectReorder: (projectId: number, newOrdering: number) => Promise<void>
+  onProjectClick?: (projectId: number) => void
+}
+
+export function ProjectListing({
+  categoryName,
+  projects,
+  onBack,
+  onProjectReorder,
+  onProjectClick
+}: ProjectListingProps) {
+  const [draggedItem, setDraggedItem] = useState<number | null>(null)
+  const [dragOverItem, setDragOverItem] = useState<number | null>(null)
+
+  const handleDragStart = useCallback((e: React.DragEvent, projectId: number) => {
+    setDraggedItem(projectId)
+    e.dataTransfer.effectAllowed = 'move'
+  }, [])
+
+  const handleDragOver = useCallback((e: React.DragEvent, projectId: number) => {
+    e.preventDefault()
+    if (draggedItem && draggedItem !== projectId) {
+      setDragOverItem(projectId)
+    }
+  }, [draggedItem])
+
+  const handleDragLeave = useCallback(() => {
+    setDragOverItem(null)
+  }, [])
+
+  const handleDrop = useCallback(async (e: React.DragEvent, targetProjectId: number) => {
+    e.preventDefault()
+
+    if (!draggedItem || draggedItem === targetProjectId) {
+      setDraggedItem(null)
+      setDragOverItem(null)
+      return
+    }
+
+    const draggedProject = projects.find(p => p.id === draggedItem)
+    const targetProject = projects.find(p => p.id === targetProjectId)
+
+    if (draggedProject && targetProject) {
+      await onProjectReorder(draggedProject.id, targetProject.ordering)
+      await onProjectReorder(targetProject.id, draggedProject.ordering)
+    }
+
+    setDraggedItem(null)
+    setDragOverItem(null)
+  }, [draggedItem, projects, onProjectReorder])
+
+  const sortedProjects = [...projects].sort((a, b) => a.ordering - b.ordering)
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-4 mb-6">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          Volver
+        </Button>
+        <div>
+          <h1 className="text-2xl font-bold">{categoryName}</h1>
+          <p className="text-sm text-muted-foreground">
+            {projects.length} proyecto{projects.length !== 1 ? 's' : ''}
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {sortedProjects.map((project) => (
+          <Card
+            key={project.id}
+            className={cn(
+              "relative group overflow-hidden transition-all cursor-pointer hover:shadow-md",
+              draggedItem === project.id && "opacity-50 scale-95",
+              dragOverItem === project.id && "ring-2 ring-primary ring-offset-2"
+            )}
+            draggable
+            onDragStart={(e) => handleDragStart(e, project.id)}
+            onDragOver={(e) => handleDragOver(e, project.id)}
+            onDragLeave={handleDragLeave}
+            onDrop={(e) => handleDrop(e, project.id)}
+            onClick={() => onProjectClick?.(project.id)}
+          >
+            <div className="relative aspect-square w-full overflow-hidden">
+              {project.first_image_url ? (
+                <img
+                  src={project.first_image_url}
+                  alt={project.name}
+                  className="absolute inset-0 w-full h-full object-cover"
+                />
+              ) : (
+                <div className="flex items-center justify-center w-full h-full bg-muted">
+                  <ImageIcon className="w-12 h-12 text-muted-foreground" />
+                </div>
+              )}
+
+              <Badge variant="secondary" className="absolute top-2 right-2">
+                #{project.ordering}
+              </Badge>
+
+              <div className="absolute inset-0 flex items-center justify-center transition-opacity opacity-0 bg-black/50 group-hover:opacity-100">
+                <div className="p-2 rounded-md cursor-move bg-white/10 backdrop-blur-sm">
+                  <GripVertical className="w-6 h-6 text-white" />
+                </div>
+              </div>
+            </div>
+
+            <div className="p-4">
+              <h3 className="font-medium truncate">{project.name}</h3>
+              <p className="text-xs text-muted-foreground">
+                Creado: {new Date(project.created_at).toLocaleDateString()}
+              </p>
+            </div>
+          </Card>
+        ))}
+      </div>
+
+      {projects.length === 0 && (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center">
+            <ImageIcon className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
+            <h3 className="text-lg font-medium text-muted-foreground mb-2">
+              No hay proyectos en esta categoría
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              Crea tu primer proyecto para comenzar
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/actions/folders.ts
+++ b/src/lib/actions/folders.ts
@@ -1,4 +1,4 @@
-import { 
+import {
   createFolder,
   getParentCategories,
   getProjectsByCategory,
@@ -8,16 +8,19 @@ import {
   getFolderWithRelatedProjects,
   getAllProjectsForSelection,
   getProjectsGroupedByCategory,
+  getProjectsWithFirstImage,
   updateFolder,
   updateFolderHero,
+  updateProjectOrdering,
   deleteFolder
 } from '../../modules/database'
-import type { 
-  FolderRecord, 
-  CategoryWithProjects, 
+import type {
+  FolderRecord,
+  CategoryWithProjects,
   CreateFolderParams,
   UpdateFolderParams,
-  FolderWithRelatedProjects 
+  FolderWithRelatedProjects,
+  ProjectWithFirstImage
 } from '../../modules/database'
 
 export const createProjectFolder = async (
@@ -201,6 +204,39 @@ export const deleteProjectFolder = async (
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Failed to delete project'
+    }
+  }
+}
+
+export const getProjectsWithFirstImageAction = async (
+  categoryId: number
+): Promise<{ success: boolean; data?: ProjectWithFirstImage[]; error?: string }> => {
+  try {
+    const projects = await getProjectsWithFirstImage(categoryId)
+    return { success: true, data: projects }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to get projects with first image'
+    }
+  }
+}
+
+export const updateProjectOrderingAction = async (
+  projectId: number,
+  newOrdering: number
+): Promise<{ success: boolean; data?: FolderRecord; error?: string }> => {
+  try {
+    const project = await updateProjectOrdering(projectId, newOrdering)
+    if (project) {
+      return { success: true, data: project }
+    } else {
+      return { success: false, error: 'Project not found' }
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to update project ordering'
     }
   }
 }

--- a/src/lib/actions/index.ts
+++ b/src/lib/actions/index.ts
@@ -18,5 +18,7 @@ export {
   getProjectsForCategory,
   getCategoriesWithProjectsAction,
   getFolderAction,
+  getProjectsWithFirstImageAction,
+  updateProjectOrderingAction,
   deleteProjectFolder
 } from './folders'

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,10 @@
+export const BASE_FOLDERS = [
+  'Fotografías',
+  'Diseño editorial',
+  'Diseño gráfico',
+  'Branding & identidad',
+  'Ilustración',
+  'Dirección de arte'
+] as const
+
+export type BaseFolderName = typeof BASE_FOLDERS[number]

--- a/src/modules/database/index.ts
+++ b/src/modules/database/index.ts
@@ -19,8 +19,10 @@ export {
   getFolderWithRelatedProjects,
   getAllProjectsForSelection,
   getProjectsGroupedByCategory,
+  getProjectsWithFirstImage,
   updateFolder,
   updateFolderHero,
+  updateProjectOrdering,
   deleteFolder
 } from './folders'
 
@@ -34,5 +36,6 @@ export type {
   UpdateMediaOrderParams,
   UpdateFolderParams,
   UpdateRelatedProjectsParams,
-  FolderWithRelatedProjects
+  FolderWithRelatedProjects,
+  ProjectWithFirstImage
 } from './types'

--- a/src/modules/database/types.ts
+++ b/src/modules/database/types.ts
@@ -7,6 +7,7 @@ export type FolderRecord = {
   hero_image_url: string | null
   related_project_1_id: number | null
   related_project_2_id: number | null
+  ordering: number
   created_at: Date
   updated_at: Date
 }
@@ -72,4 +73,8 @@ export type UpdateRelatedProjectsParams = {
 export type FolderWithRelatedProjects = FolderRecord & {
   related_project_1?: FolderRecord | null
   related_project_2?: FolderRecord | null
+}
+
+export type ProjectWithFirstImage = FolderRecord & {
+  first_image_url?: string | null
 }


### PR DESCRIPTION
Adds an ordering field to the folders table, allowing projects to be ordered within their respective categories.

Introduces a new 'ProjectListing' component to display projects in a category-specific view, with drag-and-drop reordering functionality.

Updates the UI to allow users to navigate to a category listing and reorder projects.

Also includes a database migration to add the `ordering` field and backfill existing data.